### PR TITLE
bugfix:误触体力与星导石"+"按钮

### DIFF
--- a/WFHelper.py
+++ b/WFHelper.py
@@ -38,7 +38,7 @@ class WFHelper():
         while self.isRunning:
             screen = readImageFromBytes(adbUtil.getScreen())
             self.screen = screen
-            adbUtil.touchScreen((0,0,config.picSize[0],2))
+            adbUtil.touchScreen((0, 0, config.picSize[0]/2, 2))
             if self.check(selfTarget,screen):
                 adbUtil.touchScreen(selfTarget["area"])
                 
@@ -84,7 +84,7 @@ class WFHelper():
             #300秒未操作则随机点击一次
             if t - self.lastActionTime > 300:
                 Log.info("长时间未操作，随机点击一次")
-                adbUtil.touchScreen((0,0,config.picSize[0],2))
+                adbUtil.touchScreen((0, 0, config.picSize[0]/2, 2))
                 self.lastActionTime = t
 
         ## 当脚本被远程停止时，持续更新lastActionTime


### PR DESCRIPTION
改为 config.picSize[0]/2 后，x 轴只点击前半区域，避免误触