### PR TITLE
修复清华源拉取失败的问题

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,5 +1,5 @@
 [[source]]
-url = "https://pypi.tuna.tsinghua.edu.cn/simple"
+url = "https://pypi.tuna.tsinghua.edu.cn/simple/"
 verify_ssl = true
 name = "pypi"
 


### PR DESCRIPTION
漏一个`/`的话会报错