### PR TITLE
检测到游戏进程停止后，自动启动游戏

### DIFF
--- a/utils/ADBUtil.py
+++ b/utils/ADBUtil.py
@@ -96,6 +96,12 @@ class ADBUtil:
             Log.error("获取设备信息失败")
             sys.exit()
 
+    def checkHeartbeat(self):
+        wfPid = self.device.get_pid("com.leiting.wf")
+        if wfPid is None:
+            os.system('adb shell am start -n com.leiting.wf/air.com.leiting.wf.AppEntry')
+            Log.info("游戏已停止运行，启动游戏")
+
     def __init__(self):
         if getattr(sys, "frozen", None):
             basedir = sys._MEIPASS

--- a/wfhelper/WFHelper.py
+++ b/wfhelper/WFHelper.py
@@ -56,6 +56,7 @@ class WFHelper:
             Log.info("长时间未操作，随机点击一次")
             adbUtil.touchScreen(self.config.randomClickArea)
             self.updateActionTime(t)
+            adbUtil.checkHeartbeat()
         return False
 
     def loopDelay(self):


### PR DESCRIPTION
在”长时间未操作，随机点击一次“的操作后添加检测，如果游戏停止运行，则自动启动游戏，以解决游戏闪退造成的问题。